### PR TITLE
feat(agent): on_error hook at transport/encryption failure points (O2)

### DIFF
--- a/guard_agent/models.py
+++ b/guard_agent/models.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any, Literal
 from urllib.parse import urlparse
@@ -140,6 +141,16 @@ class AgentConfig(BaseModel):
     payload_signing_secret: str | None = Field(
         default=None,
         description="HMAC-SHA256 secret for X-Payload-Signature header",
+    )
+
+    on_error: Callable[[str, BaseException, dict[str, Any]], None] | None = Field(
+        default=None,
+        description=(
+            "Optional best-effort callback invoked when a transport or encryption "
+            "step fails, receiving (stage, exception, context). stage is one of "
+            "'transport_send' / 'encryption'. A callback that raises is caught and "
+            "logged, never propagated."
+        ),
     )
 
     @field_validator("endpoint")

--- a/guard_agent/transport.py
+++ b/guard_agent/transport.py
@@ -175,6 +175,19 @@ class HTTPTransport(TransportProtocol):
         if self._client and not self._client.is_closed:
             await self._client.aclose()
 
+    def _fire_error_hook(
+        self, stage: str, exc: BaseException, context: dict[str, Any]
+    ) -> None:
+        hook = self.config.on_error
+        if hook is None:
+            return
+        try:
+            hook(stage, exc, context)
+        except Exception as hook_error:
+            self.logger.error(
+                f"on_error hook raised while handling '{stage}': {hook_error}"
+            )
+
     async def send_events(self, events: list[SecurityEvent]) -> bool:
         """Send security events to the SaaS platform.
 
@@ -308,6 +321,9 @@ class HTTPTransport(TransportProtocol):
                     f"response: {e.detail}"
                 )
                 self.requests_failed += 1
+                self._fire_error_hook(
+                    "transport_send", e, {"endpoint": endpoint, "data_type": data_type}
+                )
                 return False
             except Exception as e:
                 self.logger.warning(
@@ -320,6 +336,11 @@ class HTTPTransport(TransportProtocol):
                 else:
                     self.logger.error(f"All retry attempts failed for {data_type}")
                     self.requests_failed += 1
+                    self._fire_error_hook(
+                        "transport_send",
+                        e,
+                        {"endpoint": endpoint, "data_type": data_type},
+                    )
 
         return False
 
@@ -460,6 +481,7 @@ class HTTPTransport(TransportProtocol):
                 f"Aborting encrypted POST to {encrypted_url}; "
                 f"payload serialization failed and batch retained: {e}"
             )
+            self._fire_error_hook("encryption", e, {"endpoint": encrypted_url})
             return False
         body, headers = self._maybe_compress(json_data)
         signature = sign_payload(body, secret=self.config.payload_signing_secret)
@@ -481,6 +503,7 @@ class HTTPTransport(TransportProtocol):
                 f"Aborting POST to {url}; "
                 f"payload serialization failed and batch retained: {e}"
             )
+            self._fire_error_hook("transport_send", e, {"endpoint": url})
             return False
         body, headers = self._maybe_compress(json_data)
         signature = sign_payload(body, secret=self.config.payload_signing_secret)

--- a/guard_agent/transport.py
+++ b/guard_agent/transport.py
@@ -268,6 +268,32 @@ class HTTPTransport(TransportProtocol):
             self.logger.error(f"Failed to send status: {str(e)}")
             return False
 
+    def _evaluate_send_result(self, result: Any, data_type: str) -> bool | None:
+        """Return True (accepted), False (partial failure), or None (retry)."""
+        if isinstance(result, dict) and (
+            result.get("success") is False or result.get("errors")
+        ):
+            self.logger.warning(
+                f"Server acknowledged {data_type} batch with partial failure: "
+                f"success={result.get('success')!r} errors={result.get('errors')!r}"
+            )
+            self.requests_failed += 1
+            return False
+        if result:
+            self.requests_sent += 1
+            self.logger.debug(f"Successfully sent {data_type} batch")
+            return True
+        self.requests_failed += 1
+        return None
+
+    async def _sleep_or_record_giveup(self, attempt: int, delay: float) -> bool:
+        """Sleep to retry (return True) or record a final failure (return False)."""
+        if attempt < self.config.retry_attempts:
+            await asyncio.sleep(delay)
+            return True
+        self.requests_failed += 1
+        return False
+
     async def _send_with_retry(
         self, endpoint: str, data: dict[str, Any], data_type: str
     ) -> bool:
@@ -286,24 +312,9 @@ class HTTPTransport(TransportProtocol):
                     self._make_request, "POST", endpoint, data
                 )
 
-                if isinstance(result, dict) and (
-                    result.get("success") is False or result.get("errors")
-                ):
-                    success = result.get("success")
-                    errors = result.get("errors")
-                    self.logger.warning(
-                        f"Server acknowledged {data_type} batch with partial "
-                        f"failure: success={success!r} errors={errors!r}"
-                    )
-                    self.requests_failed += 1
-                    return False
-
-                if result:
-                    self.requests_sent += 1
-                    self.logger.debug(f"Successfully sent {data_type} batch")
-                    return True
-                else:
-                    self.requests_failed += 1
+                outcome = self._evaluate_send_result(result, data_type)
+                if outcome is not None:
+                    return outcome
 
             except RateLimitedError as e:
                 delay = min(e.retry_after_seconds, _MAX_RETRY_AFTER_SECONDS)
@@ -311,10 +322,7 @@ class HTTPTransport(TransportProtocol):
                     f"Server rate-limited {data_type}; sleeping {delay:.1f}s "
                     f"per Retry-After"
                 )
-                if attempt < self.config.retry_attempts:
-                    await asyncio.sleep(delay)
-                else:
-                    self.requests_failed += 1
+                await self._sleep_or_record_giveup(attempt, delay)
             except PermanentClientError as e:
                 self.logger.error(
                     f"Dropping {data_type} batch; non-retryable {e.status_code} "
@@ -330,12 +338,9 @@ class HTTPTransport(TransportProtocol):
                     f"Attempt {attempt + 1} failed for {data_type}: {str(e)}"
                 )
 
-                if attempt < self.config.retry_attempts:
-                    delay = calculate_backoff_delay(attempt, self.config.backoff_factor)
-                    await asyncio.sleep(delay)
-                else:
+                delay = calculate_backoff_delay(attempt, self.config.backoff_factor)
+                if not await self._sleep_or_record_giveup(attempt, delay):
                     self.logger.error(f"All retry attempts failed for {data_type}")
-                    self.requests_failed += 1
                     self._fire_error_hook(
                         "transport_send",
                         e,
@@ -513,29 +518,32 @@ class HTTPTransport(TransportProtocol):
         response = await self._client.post(url, content=body, headers=headers)
         return await self._handle_response(response)
 
+    def _handle_200(self, response: httpx.Response) -> dict[str, Any] | bool:
+        try:
+            json_data = response.json()
+        except Exception as exc:
+            self.logger.warning(
+                f"200 response with unparseable JSON body for {response.url}: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            return False
+        if isinstance(json_data, dict):
+            success = json_data.get("success")
+            errors = json_data.get("errors")
+            if success is False or errors:
+                self.logger.warning(
+                    f"200 response reported partial failure for {response.url}: "
+                    f"success={success!r} errors={errors!r}"
+                )
+            return json_data
+        return True
+
     async def _handle_response(self, response: httpx.Response) -> dict[str, Any] | bool:
         """Handle HTTP response with proper error checking."""
         self.logger.debug(f"Response: {response.status_code} for {response.url}")
 
         if response.status_code == 200:
-            try:
-                json_data = response.json()
-            except Exception as exc:
-                self.logger.warning(
-                    f"200 response with unparseable JSON body for {response.url}: "
-                    f"{type(exc).__name__}: {exc}"
-                )
-                return False
-            if isinstance(json_data, dict):
-                success = json_data.get("success")
-                errors = json_data.get("errors")
-                if success is False or errors:
-                    self.logger.warning(
-                        f"200 response reported partial failure for {response.url}: "
-                        f"success={success!r} errors={errors!r}"
-                    )
-                return json_data
-            return True
+            return self._handle_200(response)
 
         elif response.status_code == 201:
             return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 asyncio_default_fixture_loop_scope = "function"
-addopts = "--cov=guard_agent --cov-report=term-missing"
+addopts = "--cov=guard_agent --cov-branch --cov-report=term-missing"
 markers = [
     "asyncio: mark tests as async"
 ]

--- a/tests/test_transport_error_hook.py
+++ b/tests/test_transport_error_hook.py
@@ -1,0 +1,170 @@
+import base64
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from guard_agent.exceptions import PermanentClientError
+from guard_agent.models import AgentConfig, SecurityEvent
+from guard_agent.transport import HTTPTransport
+from guard_agent.utils import SerializationError
+
+
+def _config(**kwargs: Any) -> AgentConfig:
+    return AgentConfig(
+        api_key="x", endpoint="https://example.com", retry_attempts=0, **kwargs
+    )
+
+
+def _event() -> SecurityEvent:
+    return SecurityEvent(
+        timestamp=datetime.now(timezone.utc),
+        event_type="ip_banned",
+        ip_address="1.1.1.1",
+        action_taken="banned",
+        reason="t",
+    )
+
+
+def test_on_error_defaults_none() -> None:
+    assert AgentConfig(api_key="x", endpoint="https://example.com").on_error is None
+
+
+def test_on_error_accepts_callable() -> None:
+    def hook(stage: str, exc: BaseException, ctx: dict[str, Any]) -> None:
+        pass
+
+    assert _config(on_error=hook).on_error is hook
+
+
+def test_fire_error_hook_none_is_noop() -> None:
+    transport = HTTPTransport(_config())
+    transport._fire_error_hook("transport_send", ValueError("x"), {})
+
+
+def test_fire_error_hook_forwards_stage_exc_context() -> None:
+    calls: list[tuple[str, BaseException, dict[str, Any]]] = []
+    transport = HTTPTransport(
+        _config(on_error=lambda s, e, c: calls.append((s, e, c)))
+    )
+    err = ValueError("boom")
+    transport._fire_error_hook("encryption", err, {"k": "v"})
+    assert calls == [("encryption", err, {"k": "v"})]
+
+
+def test_fire_error_hook_swallows_raising_hook(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def bad_hook(stage: str, exc: BaseException, ctx: dict[str, Any]) -> None:
+        raise RuntimeError("hook fail")
+
+    transport = HTTPTransport(_config(on_error=bad_hook))
+    with caplog.at_level(logging.ERROR):
+        transport._fire_error_hook("geoip", ValueError("x"), {})
+    assert any("on_error hook raised" in r.message for r in caplog.records)
+
+
+async def test_hook_fires_on_send_exhaustion() -> None:
+    captured: list[tuple[str, BaseException, dict[str, Any]]] = []
+    transport = HTTPTransport(
+        _config(on_error=lambda s, e, c: captured.append((s, e, c)))
+    )
+    with patch.object(
+        transport, "_make_request", side_effect=httpx.HTTPError("net down")
+    ):
+        assert await transport.send_events([_event()]) is False
+    assert captured[0][0] == "transport_send"
+
+
+async def test_hook_fires_on_permanent_client_error() -> None:
+    captured: list[tuple[str, BaseException, dict[str, Any]]] = []
+    transport = HTTPTransport(
+        _config(on_error=lambda s, e, c: captured.append((s, e, c)))
+    )
+    transport._client = AsyncMock()
+    with patch.object(
+        transport, "_make_request", side_effect=PermanentClientError(400, "bad")
+    ):
+        assert await transport.send_events([_event()]) is False
+    assert captured[0][0] == "transport_send"
+
+
+async def test_hook_fires_on_unencrypted_serialization_abort() -> None:
+    captured: list[tuple[str, BaseException, dict[str, Any]]] = []
+    transport = HTTPTransport(
+        _config(on_error=lambda s, e, c: captured.append((s, e, c)))
+    )
+    transport._client = AsyncMock()
+    with patch(
+        "guard_agent.transport.safe_json_serialize",
+        side_effect=SerializationError("bad"),
+    ):
+        result = await transport._post_unencrypted(
+            "https://example.com/x", {"a": 1}
+        )
+    assert result is False
+    assert captured[0][0] == "transport_send"
+
+
+async def test_hook_fires_on_encrypted_serialization_abort() -> None:
+    captured: list[tuple[str, BaseException, dict[str, Any]]] = []
+    valid_key = base64.urlsafe_b64encode(b"a" * 32).decode()
+    transport = HTTPTransport(
+        _config(
+            project_encryption_key=valid_key,
+            on_error=lambda s, e, c: captured.append((s, e, c)),
+        )
+    )
+    transport._client = AsyncMock()
+    with patch(
+        "guard_agent.transport.safe_json_serialize",
+        side_effect=SerializationError("bad"),
+    ):
+        result = await transport._post_encrypted({"batch_id": "b", "a": 1})
+    assert result is False
+    assert captured[0][0] == "encryption"
+
+
+def test_permanent_client_error_without_detail() -> None:
+    err = PermanentClientError(404)
+    assert err.status_code == 404
+    assert str(err) == "Permanent client error 404"
+
+
+def test_endpoint_strips_legacy_api_v1_suffix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import guard_agent.models as models
+
+    monkeypatch.setattr(models, "_endpoint_suffix_warned", False)
+    config = AgentConfig(api_key="x", endpoint="https://example.com/api/v1")
+    assert config.endpoint == "https://example.com"
+
+
+def test_endpoint_strip_does_not_rewarn_when_already_warned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import guard_agent.models as models
+
+    monkeypatch.setattr(models, "_endpoint_suffix_warned", True)
+    config = AgentConfig(api_key="x", endpoint="https://example.com/api/v1")
+    assert config.endpoint == "https://example.com"
+
+
+async def test_send_with_retry_partial_failure_returns_false() -> None:
+    transport = HTTPTransport(_config())
+    with patch.object(transport, "_make_request", return_value={"success": False}):
+        assert await transport.send_events([_event()]) is False
+
+
+async def test_handle_response_200_partial_failure_returns_payload() -> None:
+    transport = HTTPTransport(_config())
+    response = MagicMock()
+    response.status_code = 200
+    response.url = "https://example.com/api/v1/events"
+    response.json = MagicMock(return_value={"success": False})
+    result = await transport._handle_response(response)
+    assert result == {"success": False}

--- a/tests/test_transport_error_hook.py
+++ b/tests/test_transport_error_hook.py
@@ -47,9 +47,7 @@ def test_fire_error_hook_none_is_noop() -> None:
 
 def test_fire_error_hook_forwards_stage_exc_context() -> None:
     calls: list[tuple[str, BaseException, dict[str, Any]]] = []
-    transport = HTTPTransport(
-        _config(on_error=lambda s, e, c: calls.append((s, e, c)))
-    )
+    transport = HTTPTransport(_config(on_error=lambda s, e, c: calls.append((s, e, c))))
     err = ValueError("boom")
     transport._fire_error_hook("encryption", err, {"k": "v"})
     assert calls == [("encryption", err, {"k": "v"})]
@@ -102,9 +100,7 @@ async def test_hook_fires_on_unencrypted_serialization_abort() -> None:
         "guard_agent.transport.safe_json_serialize",
         side_effect=SerializationError("bad"),
     ):
-        result = await transport._post_unencrypted(
-            "https://example.com/x", {"a": 1}
-        )
+        result = await transport._post_unencrypted("https://example.com/x", {"a": 1})
     assert result is False
     assert captured[0][0] == "transport_send"
 


### PR DESCRIPTION
The **guard-agent half** of the agent-error-clarity work (O2), building on guard-core's `SecurityConfig.on_error` (guard-core #25).

## What
- **`AgentConfig.on_error(stage, exc, context)`** — one best-effort callback giving integrators a programmatic signal (not just logs) when the agent transport fails. A callback that raises is caught and logged, never propagated.
- **`HTTPTransport` fires it** at the existing log-and-swallow points, each with a distinct stage:
  - send **retry-exhaustion** and non-retryable **`PermanentClientError`** → `stage="transport_send"`
  - **unencrypted** payload serialization abort → `stage="transport_send"`
  - **encrypted** payload serialization abort → `stage="encryption"`
- No behavior change when no hook is registered (logs only).

## Quality
- **100% line + branch coverage** — enabled `--cov-branch` and covered both the new code *and* pre-existing gaps it surfaced (no-detail `PermanentClientError`, legacy `/api/v1` endpoint stripping, server partial-failure paths). **Zero test warnings.**
- **Fixed pre-existing red CI:** `_send_with_retry` and `_handle_response` were already rank C (the xenon gate was failing on master). Extracted `_evaluate_send_result` / `_sleep_or_record_giveup` / `_handle_200` — behavior-preserving — so xenon now passes. All pre-commit gates green.

## Follow-up (same feature)
**fastapi-guard:** the `[agent]` extra + middleware restructure (catch `AgentPackageNotInstalledError`, honor `agent_strict`, fire `on_error`, surface agent-degraded via `get_stats`/`health_check`).

Version bump deferred — one release once all three repos land.