### PR TITLE
ci(docs): add workflow_dispatch + serialize docs deploys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,9 +15,14 @@ on:
       - 'CHANGELOG.md'
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: write
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
 
 jobs:
   deploy:


### PR DESCRIPTION
Adds a `concurrency` group (serialize `mike deploy --push` so concurrent runs can't race on gh-pages) and a `workflow_dispatch` trigger so docs can be redeployed on demand (the push trigger only watches docs paths, so docstring-only changes like O4 can't refresh the API reference until a `v*` tag). Companion fixes in guard-core + fastapi-guard.